### PR TITLE
#12 [FEAT] 회고 템플릿 목록 조회 API 구현

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/controller/ReviewController.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/controller/ReviewController.java
@@ -1,0 +1,26 @@
+package com.puzzling.puzzlingServer.api.review.controller;
+
+import com.puzzling.puzzlingServer.api.review.dto.ReviewTemplateGetResponseDto;
+import com.puzzling.puzzlingServer.api.review.service.ReviewService;
+import com.puzzling.puzzlingServer.common.response.ApiResponse;
+import com.puzzling.puzzlingServer.common.response.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/review")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @GetMapping("template")
+    public ApiResponse<ReviewTemplateGetResponseDto> getReviewTemplateAll() {
+        return ApiResponse.success(SuccessStatus.GET_REVIEW_TEMPLATE_SUCCESS,reviewService.getReviewTemplateAll());
+    }
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/ReviewTemplateGetResponseDto.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/ReviewTemplateGetResponseDto.java
@@ -1,0 +1,22 @@
+package com.puzzling.puzzlingServer.api.review.dto;
+
+import com.puzzling.puzzlingServer.api.template.domain.ReviewTemplate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class ReviewTemplateGetResponseDto {
+
+    private Long reviewTemplateId;
+    private String reviewTemplateName;
+    private String reviewTemplateMeaning;
+
+    public static ReviewTemplateGetResponseDto of(Long reviewTemplateId,String reviewTemplateName,String reviewTemplateMeaning){
+        return new ReviewTemplateGetResponseDto(reviewTemplateId,reviewTemplateName,reviewTemplateMeaning);
+    }
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/Impl/ReviewServiceImpl.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/Impl/ReviewServiceImpl.java
@@ -1,0 +1,38 @@
+package com.puzzling.puzzlingServer.api.review.service.Impl;
+
+import com.puzzling.puzzlingServer.api.review.dto.ReviewTemplateGetResponseDto;
+import com.puzzling.puzzlingServer.api.review.service.ReviewService;
+import com.puzzling.puzzlingServer.api.template.Repository.ReviewTemplateRepository;
+import com.puzzling.puzzlingServer.api.template.domain.ReviewTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService {
+    private final ReviewTemplateRepository reviewTemplateRepository;
+
+    //@Override
+    //@Transactional
+    //public List<ReviewTemplateGetResponseDto> getReviewTemplateAll() {
+    //    List<ReviewTemplate> reviewTemplates = reviewTemplateRepository.findAll();
+    //    return reviewTemplates.stream()
+    //            .flatMap(reviewTemplate -> reviewTemplateRepository.findAll())
+    //            .map(reviewTemplate -> ReviewTemplateGetResponseDto.of(reviewTemplate))
+    //            .collect(Collectors.toList());
+    //
+    //}
+    @Override
+    @Transactional
+    public List<ReviewTemplateGetResponseDto> getReviewTemplateAll() {
+        List<ReviewTemplate> reviewTemplates = reviewTemplateRepository.findAll();
+        return reviewTemplates.stream()
+                .map(reviewTemplate -> ReviewTemplateGetResponseDto.of(reviewTemplate.getId(),reviewTemplate.getName(),reviewTemplate.getMeaning()))
+                .collect(Collectors.toList());
+    }
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/Impl/ReviewServiceImpl.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/Impl/ReviewServiceImpl.java
@@ -17,16 +17,6 @@ import java.util.stream.Collectors;
 public class ReviewServiceImpl implements ReviewService {
     private final ReviewTemplateRepository reviewTemplateRepository;
 
-    //@Override
-    //@Transactional
-    //public List<ReviewTemplateGetResponseDto> getReviewTemplateAll() {
-    //    List<ReviewTemplate> reviewTemplates = reviewTemplateRepository.findAll();
-    //    return reviewTemplates.stream()
-    //            .flatMap(reviewTemplate -> reviewTemplateRepository.findAll())
-    //            .map(reviewTemplate -> ReviewTemplateGetResponseDto.of(reviewTemplate))
-    //            .collect(Collectors.toList());
-    //
-    //}
     @Override
     @Transactional
     public List<ReviewTemplateGetResponseDto> getReviewTemplateAll() {

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/ReviewService.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/ReviewService.java
@@ -1,0 +1,10 @@
+package com.puzzling.puzzlingServer.api.review.service;
+
+import com.puzzling.puzzlingServer.api.review.dto.ReviewTemplateGetResponseDto;
+import com.puzzling.puzzlingServer.api.template.domain.ReviewTemplate;
+
+import java.util.List;
+
+public interface ReviewService {
+    List<ReviewTemplateGetResponseDto> getReviewTemplateAll();
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/template/Repository/ReviewTemplateRepository.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/template/Repository/ReviewTemplateRepository.java
@@ -1,0 +1,10 @@
+package com.puzzling.puzzlingServer.api.template.Repository;
+
+import com.puzzling.puzzlingServer.api.template.domain.ReviewTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReviewTemplateRepository extends JpaRepository<ReviewTemplate, Long> {
+    List<ReviewTemplate> findAll();
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/response/SuccessStatus.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/response/SuccessStatus.java
@@ -21,6 +21,11 @@ public enum SuccessStatus {
      */
     PROJECT_VERIFY_SUCCESS(HttpStatus.OK, "초대코드 유효성 검사 성공"),
     GET_PROJECT_ALL_SUCCESS(HttpStatus.OK, "진행 중인 프로젝트 리스트 조회 성공"),
+
+    /**
+     * review
+     */
+    GET_REVIEW_TEMPLATE_SUCCESS(HttpStatus.OK,"회고 템플릿 목록 조회 성공") ;
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #12

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 회고 템플릿 목록과 내용을 조회하는 API를 개발했습니다.
![image](https://github.com/Team-Puzzling/Puzzling_Server/assets/97835512/1e675542-01b7-48e2-845a-678ed560e4d5)

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
