### PR TITLE
#30 [FEAT] 기간 내의 팀원 회고 상황 조회 API

### DIFF
--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/domain/UserProject.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/domain/UserProject.java
@@ -1,13 +1,10 @@
 package com.puzzling.puzzlingServer.api.project.domain;
 
 import com.puzzling.puzzlingServer.api.member.domain.Member;
-import com.puzzling.puzzlingServer.api.template.domain.ReviewTemplate;
 import com.puzzling.puzzlingServer.common.entity.BaseTimeEntity;
-import io.micrometer.core.annotation.Counted;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/dto/request/ProjectRegisterRequestDto.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/dto/request/ProjectRegisterRequestDto.java
@@ -7,8 +7,6 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 
-import java.lang.reflect.Array;
-import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/service/Impl/ProjectServiceImpl.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/service/Impl/ProjectServiceImpl.java
@@ -17,7 +17,6 @@ import com.puzzling.puzzlingServer.common.exception.NotFoundException;
 import com.puzzling.puzzlingServer.common.response.ErrorStatus;
 import com.puzzling.puzzlingServer.common.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
-import org.apache.catalina.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -26,11 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.ByteBuffer;
 import java.security.Principal;
-import java.security.SecureRandom;
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.TextStyle;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/controller/ReviewController.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/controller/ReviewController.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.List;
 
 
 @RestController

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/controller/ReviewController.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import com.puzzling.puzzlingServer.api.review.dto.response.ReviewActionPlanRespo
 import com.puzzling.puzzlingServer.api.review.dto.request.ReviewAARRequestDto;
 import com.puzzling.puzzlingServer.api.review.dto.response.ReviewPreviousTemplateResponseDto;
 
+import com.puzzling.puzzlingServer.api.review.dto.response.ReviewTeamStatusResponseDto;
 import com.puzzling.puzzlingServer.api.review.dto.response.ReviewTemplateGetResponseDto;
 import com.puzzling.puzzlingServer.api.review.dto.request.ReviewTILRequestDto;
 import com.puzzling.puzzlingServer.api.review.service.ReviewService;
@@ -49,12 +50,18 @@ public class ReviewController {
   
     @GetMapping("member/{memberId}/project/{projectId}/review/previous-template")
     public ApiResponse<ReviewPreviousTemplateResponseDto> getPreviousReviewTemplate(@PathVariable Long memberId, @PathVariable Long projectId) {
-        return ApiResponse.success(SuccessStatus.GET_REVIEW_PREVIOUS_TEMPLATE, reviewService.getPreviousReviewTemplate(memberId, projectId));
+        return ApiResponse.success(SuccessStatus.GET_REVIEW_PREVIOUS_TEMPLATE_SUCCESS, reviewService.getPreviousReviewTemplate(memberId, projectId));
 
     }
 
     @GetMapping("member/{memberId}/project/{projectId}/actionplan")
     public ApiResponse<ReviewActionPlanResponseDto> getReviewActionPlans(@PathVariable Long memberId, @PathVariable Long projectId) {
-        return ApiResponse.success(SuccessStatus.GET_REVIEW_ACTION_PLAN, reviewService.getReviewActionPlans(memberId, projectId));
+        return ApiResponse.success(SuccessStatus.GET_REVIEW_ACTION_PLAN_SUCCESS, reviewService.getReviewActionPlans(memberId, projectId));
+    }
+
+    @GetMapping("project/{projectId}/team/review")
+    public ApiResponse<ReviewTeamStatusResponseDto> getTeamReviewStatus(@PathVariable Long projectId, @RequestParam String startDate,
+                                                                        @RequestParam String endDate) {
+        return ApiResponse.success(SuccessStatus.GET_REVIEW_TEAM_STATUS_SUCCESS, reviewService.getTeamReviewStatus(projectId, startDate, endDate));
     }
 }

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/request/ReviewTILRequestDto.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/request/ReviewTILRequestDto.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 import static lombok.AccessLevel.PROTECTED;
 

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/response/ReviewTeamStatusResponseDto.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/response/ReviewTeamStatusResponseDto.java
@@ -1,0 +1,24 @@
+package com.puzzling.puzzlingServer.api.review.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class ReviewTeamStatusResponseDto {
+    private String reviewDay;
+    private String reviewDate;
+    private List<ReviewWriterObjectDto> reviewWriters;
+    private List<ReviewWriterObjectDto> nonReviewWriters;
+
+    public static ReviewTeamStatusResponseDto of (String reviewDay, String reviewDate, List<ReviewWriterObjectDto> reviewWriters,
+                                            List<ReviewWriterObjectDto> nonReviewWriters) {
+        return new ReviewTeamStatusResponseDto(reviewDay, reviewDate, reviewWriters, nonReviewWriters);
+    }
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/response/ReviewWriterObjectDto.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/response/ReviewWriterObjectDto.java
@@ -1,0 +1,19 @@
+package com.puzzling.puzzlingServer.api.review.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class ReviewWriterObjectDto {
+    private String memberNickname;
+    private String memberRole;
+
+    public static ReviewWriterObjectDto of (String memberNickname, String memberRole) {
+        return new ReviewWriterObjectDto(memberNickname, memberRole);
+    }
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/repository/ReviewRepository.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/repository/ReviewRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/repository/ReviewRepository.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/repository/ReviewRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
@@ -22,6 +23,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findAllByProjectIdOrderByReviewDateAsc(Long projectId);
 
-    List<Review> findAllByMemberIdAndProjectIdOrderByReviewDateAsc(Long memberId, Long projectId);
     List<Review> findAllByMemberIdAndProjectIdOrderByReviewDateDesc(Long memberId, Long projectId);
+
+    Optional<Review> findByMemberIdAndProjectIdAndReviewDate(Long memberId, Long projectId, String ReviewDate);
 }

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/Impl/ReviewServiceImpl.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/Impl/ReviewServiceImpl.java
@@ -36,10 +36,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.format.TextStyle;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -210,13 +208,10 @@ public class ReviewServiceImpl implements ReviewService {
 
         List<ReviewTeamStatusResponseDto> result = new ArrayList<>();
 
-        //1. 프로젝트 id로 userProjects 리스트 뽑아오기
         List<UserProject> userProjects = userProjectRepository.findAllByProjectId(projectId);
 
-        //2. 프로젝트 회고 주기 가져오기
         String reviewCycle = findProjectById(projectId).getReviewCycle();
 
-        //3.startDate와 endDate 사이에 회고 주기에 맞는 날짜 계산
         List<String> reviewDates = generateReviewDates(startDate, endDate, reviewCycle);
 
         for (String reviewDate : reviewDates) {

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/ReviewService.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/ReviewService.java
@@ -5,6 +5,7 @@ import com.puzzling.puzzlingServer.api.review.dto.response.ReviewActionPlanRespo
 import com.puzzling.puzzlingServer.api.review.dto.request.ReviewAARRequestDto;
 import com.puzzling.puzzlingServer.api.review.dto.response.ReviewPreviousTemplateResponseDto;
 
+import com.puzzling.puzzlingServer.api.review.dto.response.ReviewTeamStatusResponseDto;
 import com.puzzling.puzzlingServer.api.review.dto.response.ReviewTemplateGetResponseDto;
 import com.puzzling.puzzlingServer.api.review.dto.request.ReviewTILRequestDto;
 
@@ -23,4 +24,6 @@ public interface ReviewService {
     ReviewPreviousTemplateResponseDto getPreviousReviewTemplate(Long memberId, Long projectId);
 
     List<ReviewActionPlanResponseDto> getReviewActionPlans(Long memberId, Long projectId);
+
+    List<ReviewTeamStatusResponseDto> getTeamReviewStatus(Long projectId, String startDate, String endDate);
 }

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/advice/ControllerExceptionAdvice.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/advice/ControllerExceptionAdvice.java
@@ -11,14 +11,11 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.format.DateTimeParseException;
 import java.util.Objects;
 
-
 import static com.puzzling.puzzlingServer.common.response.ErrorStatus.KAKAO_UNAUTHORIZED_USER;
-import static com.puzzling.puzzlingServer.common.response.ErrorStatus.VALIDATION_PATH_MISSING_EXCEPTION;
 
 @RestControllerAdvice
 public class ControllerExceptionAdvice {

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/config/jwt/JwtTokenProvider.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/config/jwt/JwtTokenProvider.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import javax.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.util.Date;
-import java.util.Objects;
+
 
 @Slf4j
 @Component

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/response/ErrorStatus.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/response/ErrorStatus.java
@@ -3,7 +3,6 @@ package com.puzzling.puzzlingServer.common.response;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/response/SuccessStatus.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/response/SuccessStatus.java
@@ -33,8 +33,9 @@ public enum SuccessStatus {
      */
     GET_REVIEW_TEMPLATE_SUCCESS(HttpStatus.OK,"회고 템플릿 목록 조회 성공"),
     POST_REVIEW_SUCCESS(HttpStatus.CREATED,"회고 글 작성 성공"),
-    GET_REVIEW_PREVIOUS_TEMPLATE(HttpStatus.OK, "이전 회고 템플릿 조회 성공"),
-    GET_REVIEW_ACTION_PLAN(HttpStatus.OK, "ACTIONPLAN 내용 조회 성공")
+    GET_REVIEW_PREVIOUS_TEMPLATE_SUCCESS(HttpStatus.OK, "이전 회고 템플릿 조회 성공"),
+    GET_REVIEW_ACTION_PLAN_SUCCESS(HttpStatus.OK, "ACTIONPLAN 내용 조회 성공"),
+    GET_REVIEW_TEAM_STATUS_SUCCESS(HttpStatus.OK, "팀원 회고 상황 조회 성공")
     ;
   
     private final HttpStatus httpStatus;

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/util/DateUtil.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/util/DateUtil.java
@@ -1,0 +1,32 @@
+package com.puzzling.puzzlingServer.common.util;
+
+import lombok.RequiredArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+@RequiredArgsConstructor
+public class DateUtil {
+
+    public static Boolean checkTodayIsReviewDay(String today, String reviewCycle) {
+        String dayOfWeekKorean = getDayOfWeek(today);
+        List<String> weekdayList = Arrays.asList(reviewCycle.split(","));
+        return weekdayList.contains(dayOfWeekKorean);
+    }
+
+    public static String getDayOfWeek(String dateStr) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDate todayDate = LocalDate.parse(dateStr, formatter);
+
+        DayOfWeek dayOfWeek = todayDate.getDayOfWeek();
+        Locale koreanLocale = new Locale("ko", "KR");
+        String dayOfWeekKorean = dayOfWeek.getDisplayName(TextStyle.SHORT, koreanLocale);
+
+        return dayOfWeekKorean;
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #30 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- query parameter로 오는 startDate와 endDate 사이의 기간에서 프로젝트의 회고 주기에 맞는 날짜를 먼저 뽑아내고, 그 날에 회고를 작성한 멤버와 작성하지 않은 멤버의 리스트를 반환하는 API를 개발했습니다.

<img width="965" alt="image" src="https://github.com/Team-Puzzling/Puzzling_Server/assets/68415644/806e1c27-6938-419d-93eb-494beb77fc51">


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- Date에 대한 가공을 하는 것은 DateUtil로 빼서 공통적으로 Date를 가공하는 함수들을 구현했습니다.


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
