### PR TITLE
#37 [FEAT] 기간에 따른 회고 상세 조회 API

### DIFF
--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/service/Impl/ProjectServiceImpl.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/service/Impl/ProjectServiceImpl.java
@@ -177,11 +177,11 @@ public class ProjectServiceImpl implements ProjectService {
         if ( projectJoinRequestDto.getProjectId() == null ) {
             throw new BadRequestException("공백일 수 없습니다. (reviewTemplateId)");
         }
-        if (userProjectRepository.existsByMemberIdAndProjectId(memberId, projectJoinRequestDto.getProjectId())){
-            throw new BadRequestException(("이미 프로젝트에 참여한 팀원입니다."));
-        }
         if (userProjectRepository.existsByProjectIdAndNickname(projectJoinRequestDto.getProjectId(),projectJoinRequestDto.getMemberProjectNickname())){
             throw new BadRequestException(("이미 프로젝트에 있는 닉네임입니다."));
+        }
+        if (userProjectRepository.existsByMemberIdAndProjectId(memberId, projectJoinRequestDto.getProjectId())){
+            throw new BadRequestException(("이미 프로젝트에 참여한 팀원입니다."));
         }
         Member member = findMemberById(memberId);
         Project project = findProjectById(projectJoinRequestDto.getProjectId());

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/controller/ReviewController.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/controller/ReviewController.java
@@ -1,13 +1,9 @@
 package com.puzzling.puzzlingServer.api.review.controller;
 
 import com.puzzling.puzzlingServer.api.review.dto.request.Review5FRequestDto;
-import com.puzzling.puzzlingServer.api.review.dto.response.MyReviewProjectResponseDto;
-import com.puzzling.puzzlingServer.api.review.dto.response.ReviewActionPlanResponseDto;
+import com.puzzling.puzzlingServer.api.review.dto.response.*;
 import com.puzzling.puzzlingServer.api.review.dto.request.ReviewAARRequestDto;
-import com.puzzling.puzzlingServer.api.review.dto.response.ReviewPreviousTemplateResponseDto;
 
-import com.puzzling.puzzlingServer.api.review.dto.response.ReviewTeamStatusResponseDto;
-import com.puzzling.puzzlingServer.api.review.dto.response.ReviewTemplateGetResponseDto;
 import com.puzzling.puzzlingServer.api.review.dto.request.ReviewTILRequestDto;
 import com.puzzling.puzzlingServer.api.review.service.ReviewService;
 import com.puzzling.puzzlingServer.common.response.ApiResponse;
@@ -63,6 +59,12 @@ public class ReviewController {
     public ApiResponse<ReviewTeamStatusResponseDto> getTeamReviewStatus(@PathVariable Long projectId, @RequestParam String startDate,
                                                                         @RequestParam String endDate) {
         return ApiResponse.success(SuccessStatus.GET_REVIEW_TEAM_STATUS_SUCCESS, reviewService.getTeamReviewStatus(projectId, startDate, endDate));
+    }
+
+    @GetMapping("member/{memberId}/project/{projectId}/team/review")
+    public ApiResponse<ReviewDetailResponseDto> getMyReviewDetail(@PathVariable Long memberId, @PathVariable Long projectId,
+                                                                  @RequestParam String startDate, @RequestParam String endDate) {
+        return ApiResponse.success(SuccessStatus.GET_MY_REVIEWS_DETAIL_SUCCESS, reviewService.getMyReviewDetail(memberId, projectId, startDate, endDate));
     }
 
     @GetMapping("member/{memberId}/project/{projectId}/review")

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/response/ReviewContentObjectDto.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/response/ReviewContentObjectDto.java
@@ -1,0 +1,19 @@
+package com.puzzling.puzzlingServer.api.review.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class ReviewContentObjectDto {
+    private String title;
+    private String content;
+
+    public static ReviewContentObjectDto of (String title, String content) {
+        return new ReviewContentObjectDto(title, content);
+    }
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/response/ReviewDetailResponseDto.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/dto/response/ReviewDetailResponseDto.java
@@ -1,0 +1,26 @@
+package com.puzzling.puzzlingServer.api.review.dto.response;
+
+import com.puzzling.puzzlingServer.api.review.domain.Review;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor
+public class ReviewDetailResponseDto {
+    private Long reviewId;
+    private String reviewDay;
+    private String reviewDate;
+    private Long reviewTemplateId;
+    private List<ReviewContentObjectDto> contents;
+
+    public static ReviewDetailResponseDto of (Long reviewId, String reviewDay, String reviewDate,
+                                                Long reviewTemplateId, List<ReviewContentObjectDto> contents) {
+        return new ReviewDetailResponseDto(reviewId, reviewDay, reviewDate, reviewTemplateId, contents);
+    }
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/Impl/ReviewServiceImpl.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/Impl/ReviewServiceImpl.java
@@ -33,6 +33,7 @@ import com.puzzling.puzzlingServer.api.template.strategy.ReviewTemplateStrategy;
 import com.puzzling.puzzlingServer.api.template.strategy.TILReviewTemplateStrategy;
 import com.puzzling.puzzlingServer.common.exception.BadRequestException;
 import com.puzzling.puzzlingServer.common.exception.NotFoundException;
+import com.puzzling.puzzlingServer.common.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
@@ -46,8 +47,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.puzzling.puzzlingServer.common.response.ErrorStatus.NOT_FOUND_PROJECT;
-import static com.puzzling.puzzlingServer.common.util.DateUtil.checkTodayIsReviewDay;
-import static com.puzzling.puzzlingServer.common.util.DateUtil.getDayOfWeek;
+import static com.puzzling.puzzlingServer.common.util.DateUtil.*;
 
 
 @Service
@@ -88,7 +88,7 @@ public class ReviewServiceImpl implements ReviewService {
         Review review = Review.builder()
                 .userProject(userProject)
                 .reviewTemplate(reviewTemplate)
-                .reviewDate("123")
+                .reviewDate(convertLocalDatetoString(LocalDate.now()))
                 .memberId(memberId)
                 .projectId(projectId)
                 .build();
@@ -119,7 +119,7 @@ public class ReviewServiceImpl implements ReviewService {
         Review review = Review.builder()
                 .userProject(userProject)
                 .reviewTemplate(reviewTemplate)
-                .reviewDate("123")
+                .reviewDate(convertLocalDatetoString(LocalDate.now()))
                 .memberId(memberId)
                 .projectId(projectId)
                 .build();
@@ -152,7 +152,7 @@ public class ReviewServiceImpl implements ReviewService {
         Review review = Review.builder()
                 .userProject(userProject)
                 .reviewTemplate(reviewTemplate)
-                .reviewDate("123")
+                .reviewDate(convertLocalDatetoString(LocalDate.now()))
                 .memberId(memberId)
                 .projectId(projectId)
                 .build();

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/ReviewService.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/service/ReviewService.java
@@ -1,13 +1,9 @@
 package com.puzzling.puzzlingServer.api.review.service;
 
 import com.puzzling.puzzlingServer.api.review.dto.request.Review5FRequestDto;
-import com.puzzling.puzzlingServer.api.review.dto.response.MyReviewProjectResponseDto;
-import com.puzzling.puzzlingServer.api.review.dto.response.ReviewActionPlanResponseDto;
+import com.puzzling.puzzlingServer.api.review.dto.response.*;
 import com.puzzling.puzzlingServer.api.review.dto.request.ReviewAARRequestDto;
-import com.puzzling.puzzlingServer.api.review.dto.response.ReviewPreviousTemplateResponseDto;
 
-import com.puzzling.puzzlingServer.api.review.dto.response.ReviewTeamStatusResponseDto;
-import com.puzzling.puzzlingServer.api.review.dto.response.ReviewTemplateGetResponseDto;
 import com.puzzling.puzzlingServer.api.review.dto.request.ReviewTILRequestDto;
 
 
@@ -29,5 +25,7 @@ public interface ReviewService {
     List<ReviewTeamStatusResponseDto> getTeamReviewStatus(Long projectId, String startDate, String endDate);
 
     List<MyReviewProjectResponseDto> getMyReviewProjects(Long memberId, Long projectId);
+
+    List<ReviewDetailResponseDto> getMyReviewDetail(Long memberId, Long projectId, String startDate, String endDate);
 
 }

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/template/strategy/AARReviewTemplateStrategy.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/template/strategy/AARReviewTemplateStrategy.java
@@ -1,0 +1,18 @@
+package com.puzzling.puzzlingServer.api.template.strategy;
+
+import com.puzzling.puzzlingServer.api.review.dto.response.ReviewContentObjectDto;
+import com.puzzling.puzzlingServer.api.template.domain.ReviewAAR;
+
+import java.util.List;
+
+public class AARReviewTemplateStrategy implements ReviewTemplateStrategy<ReviewAAR> {
+    @Override
+    public List<ReviewContentObjectDto> getReviewContents(ReviewAAR review, List<ReviewContentObjectDto> reviewContent) {
+        reviewContent.add(new ReviewContentObjectDto("초기의 목표", review.getInitialGoal()));
+        reviewContent.add(new ReviewContentObjectDto("결과", review.getResult()));
+        reviewContent.add(new ReviewContentObjectDto("차이가 발생한 이유", review.getDifference()));
+        reviewContent.add(new ReviewContentObjectDto("지속하고 싶은 점", review.getPersistence()));
+        reviewContent.add(new ReviewContentObjectDto("앞으로의 목적", review.getActionPlan()));
+        return reviewContent;
+    }
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/template/strategy/FiveFReviewTemplateStrategy.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/template/strategy/FiveFReviewTemplateStrategy.java
@@ -1,0 +1,18 @@
+package com.puzzling.puzzlingServer.api.template.strategy;
+
+import com.puzzling.puzzlingServer.api.review.dto.response.ReviewContentObjectDto;
+import com.puzzling.puzzlingServer.api.template.domain.Review5F;
+
+import java.util.List;
+
+public class FiveFReviewTemplateStrategy implements ReviewTemplateStrategy<Review5F> {
+    @Override
+    public List<ReviewContentObjectDto> getReviewContents(Review5F review, List<ReviewContentObjectDto> reviewContent) {
+        reviewContent.add(new ReviewContentObjectDto("Fact", review.getFact()));
+        reviewContent.add(new ReviewContentObjectDto("Feeling", review.getFeeling()));
+        reviewContent.add(new ReviewContentObjectDto("Finding", review.getFinding()));
+        reviewContent.add(new ReviewContentObjectDto("Future action", review.getActionPlan()));
+        reviewContent.add(new ReviewContentObjectDto("Feedback", review.getFeedback()));
+        return reviewContent;
+    }
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/template/strategy/ReviewTemplateStrategy.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/template/strategy/ReviewTemplateStrategy.java
@@ -1,0 +1,10 @@
+package com.puzzling.puzzlingServer.api.template.strategy;
+
+import com.puzzling.puzzlingServer.api.review.domain.Review;
+import com.puzzling.puzzlingServer.api.review.dto.response.ReviewContentObjectDto;
+
+import java.util.List;
+
+public interface ReviewTemplateStrategy<T> {
+    List<ReviewContentObjectDto> getReviewContents(T review, List<ReviewContentObjectDto> reviewContent);
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/template/strategy/TILReviewTemplateStrategy.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/template/strategy/TILReviewTemplateStrategy.java
@@ -1,0 +1,17 @@
+package com.puzzling.puzzlingServer.api.template.strategy;
+
+import com.puzzling.puzzlingServer.api.review.dto.response.ReviewContentObjectDto;
+import com.puzzling.puzzlingServer.api.template.domain.ReviewTIL;
+
+import java.util.List;
+
+public class TILReviewTemplateStrategy implements ReviewTemplateStrategy<ReviewTIL> {
+    @Override
+    public List<ReviewContentObjectDto> getReviewContents(ReviewTIL review, List<ReviewContentObjectDto> reviewContent) {
+        reviewContent.add(new ReviewContentObjectDto("잘한 점", review.getLiked()));
+        reviewContent.add(new ReviewContentObjectDto("아쉬운 점", review.getLacked()));
+        reviewContent.add(new ReviewContentObjectDto("배운 점", review.getActionPlan()));
+        return reviewContent;
+    }
+
+}

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/response/SuccessStatus.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/response/SuccessStatus.java
@@ -36,7 +36,8 @@ public enum SuccessStatus {
     GET_REVIEW_PREVIOUS_TEMPLATE_SUCCESS(HttpStatus.OK, "이전 회고 템플릿 조회 성공"),
     GET_REVIEW_ACTION_PLAN_SUCCESS(HttpStatus.OK, "ACTIONPLAN 내용 조회 성공"),
     GET_REVIEW_TEAM_STATUS_SUCCESS(HttpStatus.OK, "팀원 회고 상황 조회 성공"),
-    GET_PROJECT_MY_REVIEWS_SUCCESS(HttpStatus.OK, "해당 프로젝트 내 회고 리스트 조회 성공")
+    GET_PROJECT_MY_REVIEWS_SUCCESS(HttpStatus.OK, "해당 프로젝트 내 회고 리스트 조회 성공"),
+    GET_MY_REVIEWS_DETAIL_SUCCESS(HttpStatus.OK, "회고 상세 조회 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/util/DateUtil.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/common/util/DateUtil.java
@@ -29,4 +29,9 @@ public class DateUtil {
 
         return dayOfWeekKorean;
     }
+
+    public static String convertLocalDatetoString(LocalDate localDate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return localDate.format(formatter);
+    }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #37 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기간에 따른 회고 상세 조회 API를 개발했습니다.
![image](https://github.com/Team-Puzzling/Puzzling_Server/assets/68415644/d887b8d0-53dd-4bba-87db-052c8bd6cabe)

- 회고 템플릿에 따라서도 잘 가져오는 것을 확인할 수 있습니다 !!
![image](https://github.com/Team-Puzzling/Puzzling_Server/assets/68415644/4d6281d5-20a5-4789-81ae-dfd5ba5d87ae)

- startDate와 endDate를 같게 받는다면 그 당일의 정보만 가져옵니다.
![image](https://github.com/Team-Puzzling/Puzzling_Server/assets/68415644/7751f7ce-4432-4dc3-bd69-a92f542a2712)




## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
