### PR TITLE
#58 [FIX] 개인 & 팀 대시보드 퍼즐판 로직 수정

### DIFF
--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/dto/response/ProjectOwnPuzzleResponseDto.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/dto/response/ProjectOwnPuzzleResponseDto.java
@@ -14,12 +14,13 @@ import static lombok.AccessLevel.PRIVATE;
 public class ProjectOwnPuzzleResponseDto {
     private ProjectMyPuzzleObjectDto myPuzzle;
     private List<PuzzleObjectDto> userPuzzleBoard;
+    private int puzzleBoardCount;
     private Boolean isReviewDay;
     private Boolean hasTodayReview;
 
     public static ProjectOwnPuzzleResponseDto of(ProjectMyPuzzleObjectDto projectMyPuzzleObjectDto, List<PuzzleObjectDto> userPuzzleBoard,
-                                                 Boolean isReviewDay, Boolean hasTodayReview) {
-        return new ProjectOwnPuzzleResponseDto(projectMyPuzzleObjectDto, userPuzzleBoard, isReviewDay, hasTodayReview);
+                                                 int puzzleBoardCount, Boolean isReviewDay, Boolean hasTodayReview) {
+        return new ProjectOwnPuzzleResponseDto(projectMyPuzzleObjectDto, userPuzzleBoard, puzzleBoardCount, isReviewDay, hasTodayReview);
     }
 
 }

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/dto/response/ProjectTeamPuzzleResponseDto.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/dto/response/ProjectTeamPuzzleResponseDto.java
@@ -14,11 +14,12 @@ import static lombok.AccessLevel.PRIVATE;
 public class ProjectTeamPuzzleResponseDto {
     private ProjectMyPuzzleObjectDto myPuzzle;
     private List<TeamPuzzleObjectDto> teamPuzzleBoard;
+    private int teamPuzzleBoardCount;
     private Boolean isReviewDay;
     private Boolean hasTodayReview;
 
     public static ProjectTeamPuzzleResponseDto of (ProjectMyPuzzleObjectDto projectMyPuzzleObjectDto, List<TeamPuzzleObjectDto> teamPuzzleBoard,
-                                                   Boolean isReviewDay, Boolean hasTodayReview) {
-        return new ProjectTeamPuzzleResponseDto (projectMyPuzzleObjectDto, teamPuzzleBoard, isReviewDay, hasTodayReview);
+                                                   int teamPuzzleBoardCount, Boolean isReviewDay, Boolean hasTodayReview) {
+        return new ProjectTeamPuzzleResponseDto (projectMyPuzzleObjectDto, teamPuzzleBoard, teamPuzzleBoardCount, isReviewDay, hasTodayReview);
     }
 }

--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/repository/ReviewRepository.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/review/repository/ReviewRepository.java
@@ -15,8 +15,8 @@ import java.util.Optional;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findByMemberIdAndProjectId(Long memberId, Long projectId);
 
-    @Query("SELECT r FROM Review r WHERE r.memberId = :memberId AND r.projectId = :projectId ORDER BY r.createdAt ASC")
-    Page<Review> findTop15ByMemberIdAndProjectId(@Param("memberId") Long memberId, @Param("projectId") Long projectId, Pageable pageable);
+    @Query("SELECT r FROM Review r WHERE r.memberId = :memberId AND r.projectId = :projectId ORDER BY r.createdAt")
+    Page<Review> findByMemberIdAndProjectIdOrderByCreatedAt(@Param("memberId") Long memberId, @Param("projectId") Long projectId, Pageable pageable);
 
     boolean existsReviewByReviewDate(String date);
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #58 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 개인 대시보드 및 팀 대시보드 퍼즐판에서 15개씩 페이지네이션 할 때 로직에 오류가 있었습니다.
- 해결 완.
- 퍼즐판 개수도 내려주도록 수정.

<img width="923" alt="image" src="https://github.com/Team-Puzzling/Puzzling_Server/assets/68415644/c5f14a0b-1523-469b-aedc-5a6c547d5d8b">


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
