### PR TITLE
#62 [FEAT] 개인 및 팀 대시보드 퍼즐판 빈 퍼즐까지 내려주는 로직 구현

### DIFF
--- a/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/service/Impl/ProjectServiceImpl.java
+++ b/puzzlingServer/src/main/java/com/puzzling/puzzlingServer/api/project/service/Impl/ProjectServiceImpl.java
@@ -93,16 +93,21 @@ public class ProjectServiceImpl implements ProjectService {
         Boolean hasTodayReview = reviewRepository.existsReviewByReviewDate(today);
 
         List<PuzzleObjectDto> result = new ArrayList<>();
-        for (int idx = 1; idx <= reviews.size(); idx++) {
-            Review review = reviews.get(idx - 1);
-            result.add(PuzzleObjectDto.of(review.getReviewDate(), review.getId(), ("puzzlea" + idx)));
-        }
-
-        if (isReviewDay) {
-            if (!hasTodayReview) {
-                result.add(PuzzleObjectDto.of(today, null, "puzzled" + (result.size() + 1)));
+        for (int idx = 1; idx <= pageSize; idx++) {
+            if (idx <= reviews.size()) {
+                Review review = reviews.get(idx - 1);
+                result.add(PuzzleObjectDto.of(review.getReviewDate(), review.getId(), ("puzzlea" + idx)));
+            } else {
+                if (idx == reviews.size() + 1) {
+                    if (isReviewDay && !hasTodayReview) {
+                        result.add(PuzzleObjectDto.of(today, null, "puzzled" + (result.size() + 1)));
+                    }
+                } else {
+                    result.add(PuzzleObjectDto.of(null, null, ("puzzlee" + idx)));
+                }
             }
         }
+
         return ProjectOwnPuzzleResponseDto.of(mapperMyPuzzleObject(memberId, projectId), result,
                 pageReviews.getTotalPages() - 1, isReviewDay, hasTodayReview);
     }
@@ -156,12 +161,18 @@ public class ProjectServiceImpl implements ProjectService {
             int endIndex = teamPuzzleBoard.size();
 
             lastPageValues.addAll(teamPuzzleBoard.subList(startIndex, endIndex));
+        } else {
+            lastPageValues.addAll(teamPuzzleBoard);
         }
 
         if (isReviewDay) {
             if (!hasTodayReview) {
                 lastPageValues.add(TeamPuzzleObjectDto.of(null, null, "puzzled" + (lastPageValues.size() + 1)));
             }
+        }
+
+        for (int i = lastPageValues.size() + 1; i <= pageSize ; i++) {
+            lastPageValues.add(TeamPuzzleObjectDto.of(null, null, ("puzzlee" + i)));
         }
         return ProjectTeamPuzzleResponseDto.of(mapperMyPuzzleObject(memberId, projectId), lastPageValues,
                 lastPageNumber, isReviewDay, hasTodayReview);
@@ -216,9 +227,9 @@ public class ProjectServiceImpl implements ProjectService {
         if (userProjectRepository.existsByProjectIdAndNickname(projectJoinRequestDto.getProjectId(),projectJoinRequestDto.getMemberProjectNickname())){
             throw new BadRequestException(("이미 프로젝트에 있는 닉네임입니다."));
         }
-        if (userProjectRepository.existsByMemberIdAndProjectId(memberId, projectJoinRequestDto.getProjectId())){
-            throw new BadRequestException(("이미 프로젝트에 참여한 팀원입니다."));
-        }
+//        if (userProjectRepository.existsByMemberIdAndProjectId(memberId, projectJoinRequestDto.getProjectId())){
+//            throw new BadRequestException(("이미 프로젝트에 참여한 팀원입니다."));
+//        }
         Member member = findMemberById(memberId);
         Project project = findProjectById(projectJoinRequestDto.getProjectId());
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #62 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존에 15개씩 페이지네이션 해서 내려주던 값들을 클라분들의 요청에 따라 빈 퍼즐 에셋까지도 내려주도록 구현했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
